### PR TITLE
Closed Loop Stepper Motor Class

### DIFF
--- a/ClosedLoopLinkStepperMotor.hpp
+++ b/ClosedLoopLinkStepperMotor.hpp
@@ -1,0 +1,46 @@
+#ifndef CLOSEDLOOPLINKSTEPPERMOTOR_HPP
+#define CLOSEDLOOPLINKSTEPPERMOTOR_HPP
+/**
+ * @file ClosedLoopLinkStepperMotor.hpp
+ * @author Sharwin Patil, OpenBook Robotics
+ * @brief An extension of the LinkStepperMotor class that implements closed-loop control.
+ * @version 1.0
+ * @date 2024-07-05
+ * @details Utilizes the AS5600 magnetic encoder to implement closed-loop control.
+ *
+ * @copyright Copyright (c) 2024
+ *
+ */
+
+#include <Arduino.h>
+#include <AS5600.h>
+
+ /// TODO: Implement AS5600 Encoder using library to be used as a LinkMotor
+ /// TODO: Extend the stepper motor class to include closed-loop methods or to override movement methods with CL
+
+class Encoder {
+public:
+	Encoder() = default;
+	~Encoder() = default;
+
+	bool init(void);
+
+	float getEncoderPosition(void);
+private:
+	const static AS5600 encoder = AS5600();
+	float currentEncoderPosition = 0.0;
+};
+
+class ClosedLoopLinkStepperMotor : public LinkStepperMotor {
+public:
+	ClosedLoopLinkStepperMotor() = delete;
+	~ClosedLoopLinkStepperMotor() = default;
+
+	ClosedLoopLinkStepperMotor(uint8_t stepPin, uint8_t dirPin, uint8_t enablePin, int8_t calibrationPin, uint16_t stepsPerRevolution, float gearRatio, float minAngle, float maxAngle)
+
+
+private:
+	const Encoder encoder = Encoder();
+};
+
+#endif

--- a/LinkStepperMotor.cpp
+++ b/LinkStepperMotor.cpp
@@ -28,7 +28,7 @@ unsigned long LinkStepperMotor::getPulseInterval() { return this->currentPulseIn
 
 void LinkStepperMotor::calibrate(bool calibrationDirection, bool calibrationNO) {
 	if (this->calibrationPin == -1) {
-		Logger::debug("Calibration Pin not set, skipping calibration");
+		//Logger::debug("Calibration Pin not set, skipping calibration");
 		return;
 	}
 	// Set the calibration pin to the correct mode


### PR DESCRIPTION
Extension of `LinkStepperMotor` for a Closed-loop variant. Also includes an Encoder class that will wrap the `AS5600` Arduino class but should be abstracted to accommodate other encoder implementations